### PR TITLE
replaced mphalport.h with py/mphal.h see micropython/micropython@d50e36e

### DIFF
--- a/set_mac.c
+++ b/set_mac.c
@@ -32,10 +32,10 @@
 
 #if defined(MODULE_SET_MAC_ENABLED) && MODULE_SET_MAC_ENABLED == 1
 
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/objarray.h"
 #include "py/runtime.h"
-#include "mphalport.h"
 
 #define MAC_COUNT 4
 #define MAC_LENGTH 6


### PR DESCRIPTION
This change should have no effect. But later it may have.
See recent upstream commit d50e36e.